### PR TITLE
chore: update the version of mitex

### DIFF
--- a/example.typ
+++ b/example.typ
@@ -1,4 +1,4 @@
-#import "@local/citext:0.2.0": *
+#import "@local/citext:0.3.0": *
 
 #let bib = init-citation(read("test.bib"))
 #show: show-extcite.with(bib: bib, gen-id: true)

--- a/package/lib.typ
+++ b/package/lib.typ
@@ -1,5 +1,5 @@
 #import "@preview/ctxjs:0.3.2"
-#import "@preview/mitex:0.2.4": mi
+#import "@preview/mitex:0.2.6": mi
 
 
 #let cite-src = read("./dist/index.bin", encoding: none)


### PR DESCRIPTION
The previous version triggers the following warning in Typst v0.14.2.

```log
warning: `kai` is deprecated, use ϗ or `\u{3d7}` instead
     ┌─ @preview/mitex:0.2.4/specs/latex/standard.typ:1030:30
     │
1030 │   KaTeX: of-sym(math.upright($kai A T E X$)),
     │                               ^^^
```

Besides, I strongly recommend that you document the whole build process, or setup a CI workflow.
It did take me some time to figure out how to build the project from scratch.

```shell
# Generate index.bin
# For pnpm, the following is required, or you'll meet “Rollup failed to resolve import *** from @citation-js/plugin-***”.
#   pnpm config set shamefullyHoist true --location project
npm install
npm add --save-dev terser
npm run build
cargo install --git https://github.com/lublak/typst-ctxjs-package --bin ctxjs_module_bytecode_builder
ctxjs_module_bytecode_builder citext package/dist/index.js package/dist/index.bin

# Install as a local package
# See https://crates.io/crates/cargo-binstall#installation
cargo binstall utpm
cd package && utpm workspace link && cd -

# Check
typst compile example.typ
```
